### PR TITLE
Fix resource resourceVersion inconsistency with member clusters in list/watch operation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/fleet.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/fleet.go
@@ -227,8 +227,7 @@ func (f *FleetClientSet) ListPredicate(ctx context.Context, p storage.SelectionP
 			if err != nil {
 				return err
 			}
-			setName(accessor, clusterName)
-			accessor.SetResourceVersion(responseRV.String())
+			setNameAndResourceVersion(accessor, clusterName)
 
 			items = append(items, clone)
 			num++
@@ -556,8 +555,6 @@ func (f *FleetClientSet) WatchPredicate(ctx context.Context, p storage.Selection
 	}
 
 	mrv := newMultiClusterResourceVersionFromString(resourceVersion)
-	responseRV := newMultiClusterResourceVersionFromString(resourceVersion)
-	responseRVLock := sync.Mutex{}
 	setObjectRVFunc := func(cluster string, event *watch.Event) {
 		if event == nil {
 			return
@@ -589,12 +586,7 @@ func (f *FleetClientSet) WatchPredicate(ctx context.Context, p storage.Selection
 		if err != nil {
 			return
 		}
-		setName(accessor, cluster)
-
-		responseRVLock.Lock()
-		defer responseRVLock.Unlock()
-		responseRV.set(cluster, accessor.GetResourceVersion())
-		accessor.SetResourceVersion(responseRV.String())
+		setNameAndResourceVersion(accessor, cluster)
 	}
 
 	clusters, err := f.clustersLister()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When querying resources using list or watch, the resourceVersion of the resource keeps changing, but the resourceVersion of the resource in the member cluster does not change.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix resource resourceVersion inconsistency with member clusters in list/watch operation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
